### PR TITLE
超連結使用 <a> 標籤

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,14 +15,14 @@
         <div class="col-sm-4 my-2">
             <div class="card bg-primary text-white">
                 <span class="fab fa-facebook-f" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://www.facebook.com/HackerSir.tw/')"></div>
+                <a href="https://www.facebook.com/HackerSir.tw/" class="card-img-overlay" target="_blank" title="Facebook"></a>
             </div>
         </div>
         <!-- Instagram -->
         <div class="col-sm-4 my-2">
             <div class="card bg-danger text-white">
                 <span class="fab fa-instagram" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://www.instagram.com/fcu_hackersir/')"></div>
+                <a href="https://www.instagram.com/fcu_hackersir/" class="card-img-overlay" target="_blank" title="Instagram"></a>
             </div>
         </div>
     </div>
@@ -34,21 +34,21 @@
         <div class="col-sm-4 my-2">
             <div class="card bg-secondary text-white">
                 <span class="fas fa-map-marked-alt" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://checkin.hackersir.org')"></div>
+                <a href="https://checkin.hackersir.org" class="card-img-overlay" target="_blank" title="社博打卡"></a>
             </div>
         </div>
         <!-- 學生會開票 -->
         <div class="col-sm-4 my-2">
             <div class="card bg-warning text-white">
                 <span class="fas fa-vote-yea" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://voting.hackersir.org/')"></div>
+                <a href="https://voting.hackersir.org/" class="card-img-overlay" target="_blank" title="學生會開票"></a>
             </div>
         </div>
         <!-- GitHub -->
         <div class="col-sm-4 my-2">
             <div class="card text-white bg-dark">
                 <span class="fab fa-github" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://github.com/HackerSir/')"></div>
+                <a href="https://github.com/HackerSir/" class="card-img-overlay" target="_blank" title="GitHub"></a>
             </div>
         </div>
     </div>
@@ -60,14 +60,14 @@
         <div class="col-sm-4 my-2">
             <div class="card bg-info text-white">
                 <span class="fas fa-chalkboard-teacher" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://act.hackersir.org/')"></div>
+                <a href="https://act.hackersir.org/" class="card-img-overlay" target="_blank" title="活動"></a>
             </div>
         </div>
         <!-- 課程 -->
         <div class="col-sm-4 my-2">
             <div class="card bg-primary text-white">
                 <span class="fas fa-graduation-cap" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.location = '{% url 'course' %}'"></div>
+                <a href="{% url 'course' %}" class="card-img-overlay" title="課程"></a>
             </div>
         </div>
     </div>
@@ -79,14 +79,14 @@
         <div class="col-sm-4 my-2">
             <div class="card bg-success text-white">
                 <span class="fas fa-robot" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://bot.k139.me')"></div>
+                <a href="https://bot.k139.me" class="card-img-overlay" target="_blank" title="Bot"></a>
             </div>
         </div>
         <!-- 知識王 -->
         <div class="col-sm-4 my-2">
             <div class="card bg-warning text-white">
                 <span class="far fa-lightbulb" style="font-size: 15rem;"></span>
-                <div class="card-img-overlay" onclick="javascript:window.open('https://king.hackersir.org/')"></div>
+                <a href="https://king.hackersir.org/" class="card-img-overlay" target="_blank" title="知識王"></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
首頁超連結使用`<a>`標籤實現，而非於`<div>`標籤透過`onclick`觸發 JavaScript 開啟連結

更換後優勢如下：
- 使用者可於點擊前了解連結目標網址，同時亦以 `title` 屬性說明各項超連結
- 電腦版使用者可由游標風格了解該圖塊為超連結
- 關閉 JavaScript 仍可使用
- 使該區塊為超連結這件事，在 HTML 標籤的語意上更顯而易見